### PR TITLE
Add clickable buttons to table head elements and aria-sort attribute to active table head element

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,14 +18,14 @@ const buttonVariants = cva(
           "nct-bg-secondary nct-text-secondary-foreground hover:nct-bg-secondary/80",
         ghost: "hover:nct-bg-accent hover:nct-text-accent-foreground",
         link: "nct-text-primary nct-underline-offset-4 hover:nct-underline",
-        linkTable: "nct-text-muted-foreground hover:nct-underline",
+        linkTable: "nct-text-muted-foreground",
       },
       size: {
         default: "nct-h-10 nct-px-4 nct-py-2",
         sm: "nct-h-9 nct-rounded-md nct-px-3",
         lg: "nct-h-11 nct-rounded-md nct-px-8",
         icon: "nct-h-10 nct-w-10",
-        text: "nct-h-10",
+        text: "h-auto",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,12 +18,14 @@ const buttonVariants = cva(
           "nct-bg-secondary nct-text-secondary-foreground hover:nct-bg-secondary/80",
         ghost: "hover:nct-bg-accent hover:nct-text-accent-foreground",
         link: "nct-text-primary nct-underline-offset-4 hover:nct-underline",
+        linkTable: "nct-text-muted-foreground hover:nct-underline",
       },
       size: {
         default: "nct-h-10 nct-px-4 nct-py-2",
         sm: "nct-h-9 nct-rounded-md nct-px-3",
         lg: "nct-h-11 nct-rounded-md nct-px-8",
         icon: "nct-h-10 nct-w-10",
+        text: "nct-h-10",
       },
     },
     defaultVariants: {

--- a/src/feature/cache-table/cache-panel-head.tsx
+++ b/src/feature/cache-table/cache-panel-head.tsx
@@ -101,16 +101,22 @@ export const CachePanelHead = ({
   };
 
   return (
-    <TableHead className={cn("group", className)} {...props}>
+    <TableHead className={cn("group", className)} {...props} aria-sort="ascending">
       <div
         className={cn(
           "nct-flex nct-items-center nct-gap-2 nct-py-2",
           sorting?.key === sortingProperty && "nct-underline"
         )}
       >
-        <div onClick={onHeadClick} onKeyDown={onHeadClick}>
+        <Button
+          variant="link"
+          size="sm"
+          className={cn('nct-px-0')}
+          onClick={onHeadClick}
+          onKeyDown={onHeadClick}
+        >
           {children}
-        </div>
+        </Button>
         {sortingDirection === "asc" && <ArrowDownAZIcon />}
         {sortingDirection === "desc" && <ArrowUpAZIcon />}
         {withFilter && (

--- a/src/feature/cache-table/cache-panel-head.tsx
+++ b/src/feature/cache-table/cache-panel-head.tsx
@@ -12,7 +12,6 @@ import {
 } from "../cache-panel/cache-panel-context";
 
 type TableHeadProps = Omit<React.ComponentProps<typeof TableHead>, "onClick">;
-type AriaSortAttribute = 'ascending' | 'descending' | undefined;
 
 type Props = TableHeadProps &
   React.PropsWithChildren<{
@@ -102,7 +101,7 @@ export const CachePanelHead = ({
   };
 
   const isActiveSortProperty = sorting?.key === sortingProperty;
-  const ariaSortAttribute: AriaSortAttribute = isActiveSortProperty
+  const ariaSortAttribute = isActiveSortProperty
     ? sortingDirection === "asc"
         ? 'ascending'
         : 'descending'

--- a/src/feature/cache-table/cache-panel-head.tsx
+++ b/src/feature/cache-table/cache-panel-head.tsx
@@ -117,9 +117,8 @@ export const CachePanelHead = ({
         )}
       >
         <Button
-          variant="link"
-          size="sm"
-          className={cn('nct-px-0')}
+          variant="linkTable"
+          size="text"
           onClick={onHeadClick}
           onKeyDown={onHeadClick}
         >

--- a/src/feature/cache-table/cache-panel-head.tsx
+++ b/src/feature/cache-table/cache-panel-head.tsx
@@ -124,8 +124,8 @@ export const CachePanelHead = ({
         >
           {children}
         </Button>
-        {sortingDirection === "asc" && <ArrowDownAZIcon />}
-        {sortingDirection === "desc" && <ArrowUpAZIcon />}
+        {sortingDirection === "asc" && <ArrowDownAZIcon aria-hidden />}
+        {sortingDirection === "desc" && <ArrowUpAZIcon aria-hidden />}
         {withFilter && (
           <div className="ml-auto">
             {!filterInputVisible && (

--- a/src/feature/cache-table/cache-panel-head.tsx
+++ b/src/feature/cache-table/cache-panel-head.tsx
@@ -12,6 +12,7 @@ import {
 } from "../cache-panel/cache-panel-context";
 
 type TableHeadProps = Omit<React.ComponentProps<typeof TableHead>, "onClick">;
+type AriaSortAttribute = 'ascending' | 'descending' | undefined;
 
 type Props = TableHeadProps &
   React.PropsWithChildren<{
@@ -100,12 +101,19 @@ export const CachePanelHead = ({
     }
   };
 
+  const isActiveSortProperty = sorting?.key === sortingProperty;
+  const ariaSortAttribute: AriaSortAttribute = isActiveSortProperty
+    ? sortingDirection === "asc"
+        ? 'ascending'
+        : 'descending'
+    : undefined;
+
   return (
-    <TableHead className={cn("group", className)} {...props} aria-sort="ascending">
+    <TableHead className={cn("group", className)} {...props} aria-sort={ariaSortAttribute}>
       <div
         className={cn(
           "nct-flex nct-items-center nct-gap-2 nct-py-2",
-          sorting?.key === sortingProperty && "nct-underline"
+          isActiveSortProperty && "nct-underline"
         )}
       >
         <Button


### PR DESCRIPTION
Hello, I slightly modified the markup so that the clickable labels in the table head elements are buttons. Additionally, I added the aria-sort attributes, like in the official W3C example for accessible and sortable tables: https://www.w3.org/WAI/ARIA/apg/patterns/table/examples/sortable-table/#ex_label
I added a button variant so that the new markup resembles the old one as closely as possible.

Cheers